### PR TITLE
Improve logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ If you change anything in `types.ts` (which is shared by server and frontend), b
 
 ### Log output
 
-To get debug log output, use environment variable "DEBUG" and add the names of the components to get debug output for, like in this example:
+The log level (`debug`, `info`, `warn` or `error`) can be set via environment variable "LOGLEVEL".
 
-    export DEBUG=encoder,motorset,car
+In log level `debug`, another environment variable, "DEBUG" controls, which modules are to be logged. This can be a comma separated list of module names in lower case, like in this example:
+
+    export DEBUG=encoder,motor,car

--- a/robot/Car/Car.test.ts
+++ b/robot/Car/Car.test.ts
@@ -8,6 +8,7 @@ import { create as createOrientation, fromDegrees, fromRadian } from "./Orientat
 import { create as createPosition } from "./Position"
 import { isPending } from "../lib/TestHelpers"
 import MPUFactory from "../Hardware/MPU6050"
+import TestLogger, { Logger } from "../lib/Logger"
 
 const sandbox = sinon.createSandbox()
 
@@ -17,15 +18,17 @@ describe("Car", () => {
   let car: Car
   let leftMotorSpy
   let rightMotorSpy
+  let logger: Logger
 
   beforeEach(async () => {
+    logger = TestLogger()
     leftMotorSpy = createMotorSpies(sandbox)
     rightMotorSpy = createMotorSpies(sandbox)
 
     left = MockMotor(1, leftMotorSpy)
     right = MockMotor(2, rightMotorSpy)
     const mpu = await MPUFactory({ useFake: true })
-    car = CarFactory({ left, right }, mpu)
+    car = CarFactory({ left, right }, mpu, logger)
   })
 
   afterEach(() => {

--- a/robot/ClientHandler/CommandList.ts
+++ b/robot/ClientHandler/CommandList.ts
@@ -83,7 +83,6 @@ export default function (car: Car): Record<string, CommandFunction> {
       for (let i = 0; i < 3; i += 0.3) {
         const x = 300 * Math.sin(i)
         const y = 300 * Math.cos(i)
-        console.log(x, y)
         await car.goto(createPosition(x, y))
       }
     },

--- a/robot/MotorSet/Encoder.test.ts
+++ b/robot/MotorSet/Encoder.test.ts
@@ -45,13 +45,13 @@ describe("Encoder", () => {
   })
 
   it("should log in csv format if env ist set", () => {
-    const console = Logger()
+    const logger = Logger()
     process.env.LOG = "encoder"
-    encoder = EncoderFactory(gpio, 1, 2, console)
+    encoder = EncoderFactory(gpio, 1, 2, logger)
     encoder.tick(1, 1)
     encoder.tick(1, 2)
-    console.get().length.should.equal(2)
-    const entry = console.get()[1].split(",")
+    logger.get().length.should.equal(2)
+    const entry = logger.get()[1].split(",")
     entry.length.should.equal(5)
     entry.should.containDeep(["Encoder", "2", "1838.235294117647", "1"])
     delete process.env.LOG_ENCODER

--- a/robot/MotorSet/Encoder.ts
+++ b/robot/MotorSet/Encoder.ts
@@ -1,5 +1,6 @@
 import { GPIO, INPUT, PI_NTFY_FLAGS_ALIVE } from "../Hardware/gpio"
 import createObservable, { ObservableValue } from "../lib/ObservableValue"
+import { ModuleLogger } from "../lib/Logger"
 
 export const TICKS_PER_REV = 544
 const SAMPLE_DURATION_MS = 3
@@ -22,16 +23,11 @@ const QEM = [
   [NaN, 1, -1, 0],
 ]
 
-const defaultLogger = {
-  debug: process.env.DEBUG && process.env.DEBUG.split(",").includes("encoder") ? console.debug : () => undefined,
-  error: console.error,
-}
-
 /*
   This class implements a quadrature encoder with two outputs, with a 90° phase shift.
   Specify the GPIO pins where the outputs are connecte too.
 */
-export default function (gpio: GPIO, pin_a: number, pin_b: number, logger = defaultLogger): Encoder {
+export default function (gpio: GPIO, pin_a: number, pin_b: number, logger = ModuleLogger("encoder")): Encoder {
   let oldVal = 0
   let lastTick = undefined as number | undefined
   const notifier = gpio.createNotifier([pin_a, pin_b])

--- a/robot/MotorSet/Motor.test.ts
+++ b/robot/MotorSet/Motor.test.ts
@@ -4,14 +4,16 @@ import GPIOFactory, { GPIO, INPUT, OUTPUT, PWM } from "../Hardware/gpio"
 import { Encoder } from "./Encoder"
 import MockEncoderFactory, { createEncoderSpies } from "./MockEncoder"
 import { createSandbox } from "sinon"
+import TestLogger, { Logger } from "../lib/Logger"
 
 const sandbox = createSandbox()
 
-describe("MotorSet", () => {
+describe("Motor", () => {
   let encoder: Encoder
   let motor: Motor
   let gpio: GPIO
   let encoderSpy
+  let logger: Logger
 
   function notify(pos: number, speed: number) {
     encoder.position.notify(pos)
@@ -19,10 +21,11 @@ describe("MotorSet", () => {
   }
 
   beforeEach(() => {
+    logger = TestLogger()
     gpio = GPIOFactory(true)
     encoderSpy = createEncoderSpies(sandbox)
     encoder = MockEncoderFactory(1, encoderSpy)
-    motor = MotorFactory(gpio, 1, 2, 3, encoder)
+    motor = MotorFactory(gpio, 1, 2, 3, encoder, logger)
   })
 
   afterEach(() => {

--- a/robot/lib/Logger.ts
+++ b/robot/lib/Logger.ts
@@ -37,3 +37,15 @@ function Logger(): TestLogger {
 }
 
 export default Logger
+
+const logLevel: LogLevel = (process.env.LOGLEVEL as LogLevel) || LogLevel.warn
+
+export const ModuleLogger = (moduleName: string, level = logLevel) => {
+  const debugModule = process.env.DEBUG && process.env.DEBUG.split(",").includes(moduleName)
+  return {
+    debug: level === LogLevel.debug && debugModule ? console.debug : () => undefined,
+    info: [LogLevel.debug, LogLevel.info].includes(level) ? console.info : () => undefined,
+    warn: [LogLevel.debug, LogLevel.info, LogLevel.warn].includes(level) ? console.warn : () => undefined,
+    error: console.error,
+  }
+}

--- a/robot/route/FileWriter.ts
+++ b/robot/route/FileWriter.ts
@@ -1,12 +1,19 @@
 import fs from "fs"
 import { resolve } from "path"
+import { ModuleLogger } from "../lib/Logger"
 import { RouteFormatter } from "./CSVFormatter"
 import { DataType } from "./RouteTracker"
 
-export default function FileWriter(dir: string, fileName: string, formatter: RouteFormatter) {
+export default function FileWriter(
+  dir: string,
+  name: string,
+  formatter: RouteFormatter,
+  logger = ModuleLogger("filewriter")
+) {
   fs.mkdirSync(dir, { recursive: true })
-  const file = fs.createWriteStream(resolve(dir, fileName + "." + formatter.extension), { flags: "a" })
-  console.log("Writing data to " + dir + "/" + fileName + "." + formatter.extension)
+  const filePath = resolve(dir, name + "." + formatter.extension)
+  const file = fs.createWriteStream(filePath, { flags: "a" })
+  logger.debug("Writing data to " + filePath)
   file.write(formatter.start())
 
   return {
@@ -17,7 +24,7 @@ export default function FileWriter(dir: string, fileName: string, formatter: Rou
     end(): void {
       file.write(formatter.end())
       file.end()
-      console.log("Logging data to " + dir + "/" + fileName + "." + formatter.extension + " completed.")
+      logger.debug("Logging data to " + filePath + " completed.")
     },
   }
 }


### PR DESCRIPTION
Brings several improvements:

- Logging can be controlled by setting an environment variable "LOGLEVEL" (which can be `debug`, `info`, `warn` or `error`. Default is `warn`.
- In log level `debug`, another environment variable, "DEBUG" controls, which modules are to be logged. This can be a comma separated list of module names in lower case, e.g. "car,filewriter"
- In tests, no unwanted log output is generated (like it was in `Motor`)